### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Toolkit by Ostris
 
+[![Try a demo on Replicate](https://replicate.com/lucataco/ai-toolkit/badge)](https://replicate.com/lucataco/ai-toolkit)
+
 ## IMPORTANT NOTE - READ THIS
 This is my research repo. I do a lot of experiments in it and it is possible that I will break things.
 If something breaks, checkout an earlier commit. This repo can train a lot of things, and it is


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.